### PR TITLE
Use html templates instead of unnecessary AJAX

### DIFF
--- a/bookshelf.go
+++ b/bookshelf.go
@@ -53,9 +53,7 @@ func main() {
         res.Write(data)
     })
 
-    http.HandleFunc("/getpages", getPagesHandler)
     http.HandleFunc("/read", readHandler)
-    http.HandleFunc("/getbooks", getBooksHandler)
     http.HandleFunc("/library", libraryHandler)
     http.HandleFunc("/applysettings", applySettingsHandler)
     http.HandleFunc("/settings", settingsHandler)

--- a/comicreader.go
+++ b/comicreader.go
@@ -5,7 +5,6 @@ import(
     "strconv"
     "log"
     "encoding/base64"
-    "encoding/json"
     "html/template"
     "github.com/fabiocolacio/liblit/cbz"
 )
@@ -46,34 +45,5 @@ func readHandler(res http.ResponseWriter, req *http.Request) {
     if err = t.Execute(res, b64Pages); err != nil {
         log.Println(err)
     }
-}
-
-func getPagesHandler(res http.ResponseWriter, req *http.Request) {
-    id, err := strconv.Atoi(req.URL.Query()["id"][0])
-    if err != nil {
-        res.WriteHeader(500)
-        return
-    }
-
-    if id >= len(settings.Books) {
-        res.WriteHeader(400)
-        return
-    }
-
-    path := settings.Books[id]
-    
-    pages, err := cbz.NewFromFile(path)
-    if err != nil {
-        res.WriteHeader(500)
-        return
-    }
-
-    payload, err := json.Marshal(pages)
-    if err != nil {
-        res.WriteHeader(400)
-        return
-    }
-    
-    res.Write(payload)
 }
 

--- a/html/library.htm
+++ b/html/library.htm
@@ -5,39 +5,6 @@
     </head>
 
     <body>
-        <script>
-            function getBooks() {
-                var HTTPRequest = new XMLHttpRequest();
-                HTTPRequest.onreadystatechange = function() {
-                    if (HTTPRequest.readyState == 4 && HTTPRequest.status == 200) {
-                        var books = JSON.parse(HTTPRequest.responseText);
-                        var table = document.getElementById("books");
-                        var lastRow = null;
-                        for (var i = 0; i < books.length; i++) {
-                            if (i % 5 == 0 || i == 0) {
-                               lastRow = table.insertRow(-1);
-                               colIndex = 0;
-                            }
-                            var col = lastRow.insertCell(-1);
-                            var img = new Image();
-                            var a = document.createElement('a');
-                            img.src = "data:src/png;base64, " + books[i].cover;
-                            a.appendChild(img);
-                            a.href = "/read?id=" + books[i].id;
-                            img.width = 200;
-                            col.appendChild(a);
-                        }
-                    }               
-               }
-
-                HTTPRequest.open("GET", "/getbooks", true);
-                HTTPRequest.send(null);
-
-            }
-
-
-            getBooks();
-        </script>
         <h1><em>BookShelf</em></h1>
         <ul>
             <li><a href="/library">Library</a></li>
@@ -46,14 +13,24 @@
         <br />
         <input type="text" placeholder="Search..">
         
- <!--   <div class="dropdown">
+        <!--
+        <div class="dropdown">
             <button class="dropbtn">View:</button>
             <div class="dropdown-content">
                 <a href="">GRID</a>
                 <a href="">LIST</a>
             </div>
-        </div>-->
+        </div>
+        -->
+        
         <table id="books">
+            {{if .}}
+                {{range .}}
+                    <tr><td><a href="/read?id={{.Id}}">
+                        <img width="200" src="data:src/png;base64, {{.Cover}}"/>
+                    </a></td></tr>
+                {{end}}
+            {{end}}
         </table>
     </body>
 </html>

--- a/html/settings.htm
+++ b/html/settings.htm
@@ -51,11 +51,9 @@
     
     <table border="1" id="paths">
         <tr>
-            {{block "list" .}}
-                {{if .}}
-                    {{range .}}
-                        <tr><td><input type="text" value="{{println .}}" /></td></tr>
-                    {{end}}
+            {{if .}}
+                {{range .}}
+                    <tr><td><input type="text" value="{{.}}" /></td></tr>
                 {{end}}
             {{end}}
         </tr>

--- a/html/settings.htm
+++ b/html/settings.htm
@@ -51,7 +51,7 @@
     
     <table border="1" id="paths">
         <tr>
-            {{block "list" .}}{{"\n"}}
+            {{block "list" .}}
                 {{if .}}
                     {{range .}}
                         <tr><td><input type="text" value="{{println .}}" /></td></tr>

--- a/html/view.htm
+++ b/html/view.htm
@@ -26,14 +26,10 @@
             <li><a href="/settings">Settings</a></li>
         </ul>
         <br />
-    
-            {{block "list" .}}
-                {{if .}}
-                    {{range .}}
-                        <img class="page" src="data:src/png;base64, {{println .}}" />
-                    {{end}}
+            {{if .}}
+                {{range .}}
+                    <img class="page" src="data:src/png;base64, {{.}}" />
                 {{end}}
             {{end}}
-
     </body>
 </html>

--- a/html/view.htm
+++ b/html/view.htm
@@ -19,27 +19,6 @@
                 margin-bottom: 10px;
             }
         </style>
-
-        <script>
-            function getPages() {
-                var HTTPRequest = new XMLHttpRequest();
-                HTTPRequest.onreadystatechange = function() {
-                    if (HTTPRequest.readyState == 4 && HTTPRequest.status == 200) {
-                        var pages = JSON.parse(HTTPRequest.responseText);
-                        for (var i = 0; i < pages.length; i++) {
-                            var img = new Image();
-                            img.src = "data:src/png;base64, " + pages[i];
-                            img.setAttribute("class", "page");
-                            document.body.appendChild(img);
-                        }
-                    }
-                }
-                HTTPRequest.open("GET", "/getpages?id=" + {{.Id}}, true);
-                HTTPRequest.send(null);
-            }
-
-            getPages();
-        </script>
         
         <h1><em>BookShelf</em></h1>
         <ul>
@@ -47,7 +26,14 @@
             <li><a href="/settings">Settings</a></li>
         </ul>
         <br />
-
+    
+            {{block "list" .}}
+                {{if .}}
+                    {{range .}}
+                        <img class="page" src="data:src/png;base64, {{println .}}" />
+                    {{end}}
+                {{end}}
+            {{end}}
 
     </body>
 </html>

--- a/library.go
+++ b/library.go
@@ -3,7 +3,6 @@ package main
 import(
     "github.com/fabiocolacio/liblit/cbz"
     "net/http"
-    "encoding/json"
     "encoding/base64"
     "html/template"
     "log"
@@ -46,32 +45,5 @@ func libraryHandler(res http.ResponseWriter, req *http.Request) {
     }
 
     t.Execute(res, books)
-}
-
-func getBooksHandler(res http.ResponseWriter, req *http.Request) {
-    var books []Book
-    for id, path := range settings.Books {
-        pages, err := cbz.NewFromFile(path)
-        if err != nil {
-            res.WriteHeader(500)
-            return
-        }
-
-        book := Book {
-            Type: "comic",
-            Cover: base64.StdEncoding.EncodeToString(pages[0]),
-            Id: id,
-        }
-
-        books = append(books, book)
-    }
-
-    payload, err := json.Marshal(books)
-    if err != nil {
-        res.WriteHeader(500)
-        return
-    }
-
-    res.Write(payload)
 }
 

--- a/library.go
+++ b/library.go
@@ -4,7 +4,8 @@ import(
     "github.com/fabiocolacio/liblit/cbz"
     "net/http"
     "encoding/json"
-    "io/ioutil"
+    "encoding/base64"
+    "html/template"
     "log"
 )
 
@@ -14,24 +15,37 @@ type Book struct {
     Author         string `json:"author"`
     Contributors   string `json:"contributors"`
     Subjects       string `json:"subjects"`
-    Cover        []byte   `json:"cover"`
+    Cover          string `json:"cover"`
     Id             int    `json:"id"`
 }
 
-var(
-    libraryPage []byte
-)
-
-func init() {
-    var err error
-    libraryPage, err = ioutil.ReadFile("html/library.htm")
-    if err != nil {
-        log.Fatal("Failed to load library.htm")
-    }
-}
-
 func libraryHandler(res http.ResponseWriter, req *http.Request) {
-    res.Write(libraryPage)        
+    t, err := template.ParseFiles("html/library.htm")
+    if err != nil {
+        res.WriteHeader(500)
+        log.Println(err)
+        return
+    }
+
+    var books []Book
+    for id, path := range settings.Books {
+        pages, err := cbz.NewFromFile(path)
+        if err != nil {
+            res.WriteHeader(500)
+            log.Println(err)
+            return
+        }
+
+        book := Book {
+            Type: "comic",
+            Cover: base64.StdEncoding.EncodeToString(pages[0]),
+            Id: id,
+        }
+
+        books = append(books, book)
+    }
+
+    t.Execute(res, books)
 }
 
 func getBooksHandler(res http.ResponseWriter, req *http.Request) {
@@ -45,7 +59,7 @@ func getBooksHandler(res http.ResponseWriter, req *http.Request) {
 
         book := Book {
             Type: "comic",
-            Cover: pages[0],
+            Cover: base64.StdEncoding.EncodeToString(pages[0]),
             Id: id,
         }
 

--- a/settings.go
+++ b/settings.go
@@ -14,17 +14,8 @@ type Settings struct {
 }
 
 var(
-    settingsPage []byte
     settings Settings
 )
-
-func init() {
-    var err error
-    settingsPage, err = ioutil.ReadFile("html/settings.htm")
-    if err != nil {
-        log.Fatal("Failed to read 'settings.htm':", err)
-    }
-}
 
 func applySettingsHandler(res http.ResponseWriter, req *http.Request) {
     body, err := ioutil.ReadAll(req.Body)
@@ -48,15 +39,13 @@ func applySettingsHandler(res http.ResponseWriter, req *http.Request) {
 }
 
 func settingsHandler(res http.ResponseWriter, req *http.Request) {
-    tmpl, err := template.New("settings").Parse(string(settingsPage))
+    tmpl, err := template.ParseFiles("html/settings.htm")
     if err != nil {
         log.Println("Failed to parse settings!")
-        res.Write(settingsPage)
     }
 
     if err = tmpl.Execute(res, settings.Books); err != nil {
         log.Println("Failed to execute settings template!")
-        res.Write(settingsPage)
     }
 }
 


### PR DESCRIPTION
The AJAX calls in ``/settings``, ``/library``, and ``/read`` routes have been removed, and the functionality has been replaced with html templates.